### PR TITLE
docs: separate Task schema and update references

### DIFF
--- a/docs/api/components/schemas/Task.yaml
+++ b/docs/api/components/schemas/Task.yaml
@@ -1,0 +1,33 @@
+# Task schema with immutable fields
+# describes a task with id, name, text, hints, and limits
+# using OpenAPI 3.0 schema syntax
+
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+    readOnly: true
+  name:
+    type: string
+    readOnly: true
+  text:
+    type: string
+    readOnly: true
+  hints:
+    type: array
+    readOnly: true
+    items:
+      type: string
+  timeLimit:
+    type: integer
+    description: Time limit in seconds
+    readOnly: true
+  memoryLimit:
+    type: integer
+    description: Memory limit in megabytes
+    readOnly: true
+required:
+  - id
+  - name
+  - text

--- a/docs/api/components/schemas/Team.yaml
+++ b/docs/api/components/schemas/Team.yaml
@@ -1,0 +1,16 @@
+# Team schema containing team info and task progress
+
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  tasks:
+    type: array
+    items:
+      $ref: './TeamTask.yaml'
+required:
+  - id
+  - name

--- a/docs/api/components/schemas/TeamTask.yaml
+++ b/docs/api/components/schemas/TeamTask.yaml
@@ -1,0 +1,20 @@
+# TeamTask represents progress of a team for a particular task
+
+type: object
+properties:
+  task:
+    $ref: './Task.yaml'
+  status:
+    type: string
+    description: Current status of the task for the team
+    enum: [pending, in_progress, solved]
+  attempts:
+    type: integer
+    description: Number of attempts made by the team
+  openedHints:
+    type: array
+    description: Indexes of hints opened by the team
+    items:
+      type: integer
+required:
+  - task

--- a/docs/api/components/schemas/Tournament.yaml
+++ b/docs/api/components/schemas/Tournament.yaml
@@ -1,0 +1,16 @@
+# Tournament schema including tasks with team progress information
+
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  tasks:
+    type: array
+    items:
+      $ref: './TeamTask.yaml'
+required:
+  - id
+  - name

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.3
+info:
+  title: Example Tournament API
+  version: '1.0.0'
+paths:
+  /tournaments:
+    get:
+      summary: List tournaments
+      responses:
+        '200':
+          description: List of tournaments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Tournament'
+  /teams/{teamId}/tasks:
+    get:
+      summary: List tasks for a team with progress
+      parameters:
+        - name: teamId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of team tasks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TeamTask'
+components:
+  schemas:
+    Task:
+      $ref: './components/schemas/Task.yaml'
+    TeamTask:
+      $ref: './components/schemas/TeamTask.yaml'
+    Team:
+      $ref: './components/schemas/Team.yaml'
+    Tournament:
+      $ref: './components/schemas/Tournament.yaml'


### PR DESCRIPTION
## Summary
- add standalone Task schema for immutable task fields
- link TeamTask to Task and keep only progress fields
- update Team, Tournament, and OpenAPI definitions to use new schemas

## Testing
- `npm test` *(fails: Could not read package.json)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6895d703fba883268d4efff3f76c8876