### PR TITLE
Serve static HTML via Nginx with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: install run stop
+
+install:
+	sudo apt-get update
+	sudo apt-get install -y docker.io docker-compose-plugin
+	sudo service docker start || true
+
+run:
+	docker compose -f docker-compose.nginx.yml up -d
+
+stop:
+	docker compose -f docker-compose.nginx.yml down

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 This project provides a small Kafka cluster using Docker Compose and simple Go clients for producing and consuming messages. The cluster runs Kafka in KRaft mode without ZooKeeper.
 
 ## Prerequisites
-- Docker and Docker Compose
+- Docker with Compose plugin
 - Go 1.24+
 
 ## Running the cluster
 
 Start the brokers:
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 This launches three Kafka brokers listening on local ports `19092`, `19093` and `19094`.
 
@@ -27,5 +27,5 @@ produced messages. The client will keep running until you press `Ctrl+C`.
 
 Stop the cluster with:
 ```bash
-docker-compose down
+docker compose down
 ```

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  web:
+    image: nginx:alpine
+    volumes:
+      - ./index.html:/usr/share/nginx/html/index.html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8080:80"

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Faceless Cat</title>
+</head>
+<body>
+  <h1>Welcome to facelesscat.wtf</h1>
+  <p>This is a simple HTML page served by Nginx in Docker.</p>
+</body>
+</html>

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name facelesscat.wtf;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Serve a simple HTML page via Nginx configured for facelesscat.wtf
- Add Docker Compose setup and Makefile targets for installing dependencies and running the server
- Update Makefile and docs to use `docker compose` subcommand

## Testing
- `go test ./...`
- `make install` *(fails: Unable to locate package docker-compose-plugin)*
- `make run` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ca7374b688326be6c2c06b9d98024